### PR TITLE
Initial merge of new file access routines.

### DIFF
--- a/src/backend/replication/logical/origin.c
+++ b/src/backend/replication/logical/origin.c
@@ -574,7 +574,7 @@ CheckPointReplicationOrigin(void)
 {
 	const char *tmppath = "pg_logical/replorigin_checkpoint.tmp";
 	const char *path = "pg_logical/replorigin_checkpoint";
-	int			tmpfd;
+	File		file;
 	int			i;
 	uint32		magic = REPLICATION_STATE_MAGIC;
 	pg_crc32c	crc;
@@ -595,9 +595,9 @@ CheckPointReplicationOrigin(void)
 	 * no other backend can perform this at the same time; only one checkpoint
 	 * can happen at a time.
 	 */
-	tmpfd = OpenTransientFile(tmppath,
+	file = PathNameOpenTemporaryFile(tmppath,
 							  O_CREAT | O_EXCL | O_WRONLY | PG_BINARY);
-	if (tmpfd < 0)
+	if (file < 0)
 		ereport(PANIC,
 				(errcode_for_file_access(),
 				 errmsg("could not create file \"%s\": %m",
@@ -605,16 +605,12 @@ CheckPointReplicationOrigin(void)
 
 	/* write magic */
 	errno = 0;
-	if ((write(tmpfd, &magic, sizeof(magic))) != sizeof(magic))
-	{
-		/* if write didn't set errno, assume problem is no disk space */
-		if (errno == 0)
-			errno = ENOSPC;
+	if ((FileWriteSeq(file, &magic, sizeof(magic), WAIT_EVENT_NONE)) != sizeof(magic))
 		ereport(PANIC,
 				(errcode_for_file_access(),
 				 errmsg("could not write to file \"%s\": %m",
 						tmppath)));
-	}
+	
 	COMP_CRC32C(crc, &magic, sizeof(magic));
 
 	/* prevent concurrent creations/drops */
@@ -644,19 +640,13 @@ CheckPointReplicationOrigin(void)
 
 		/* make sure we only write out a commit that's persistent */
 		XLogFlush(local_lsn);
-
-		errno = 0;
-		if ((write(tmpfd, &disk_state, sizeof(disk_state))) !=
+		
+		if ((FileWriteSeq(file, &disk_state, sizeof(disk_state), WAIT_EVENT_NONE)) !=
 			sizeof(disk_state))
-		{
-			/* if write didn't set errno, assume problem is no disk space */
-			if (errno == 0)
-				errno = ENOSPC;
 			ereport(PANIC,
 					(errcode_for_file_access(),
 					 errmsg("could not write to file \"%s\": %m",
 							tmppath)));
-		}
 
 		COMP_CRC32C(crc, &disk_state, sizeof(disk_state));
 	}
@@ -665,23 +655,13 @@ CheckPointReplicationOrigin(void)
 
 	/* write out the CRC */
 	FIN_CRC32C(crc);
-	errno = 0;
-	if ((write(tmpfd, &crc, sizeof(crc))) != sizeof(crc))
-	{
-		/* if write didn't set errno, assume problem is no disk space */
-		if (errno == 0)
-			errno = ENOSPC;
+	if ((FileWriteSeq(file, &crc, sizeof(crc), WAIT_EVENT_NONE)) != sizeof(crc))
 		ereport(PANIC,
 				(errcode_for_file_access(),
 				 errmsg("could not write to file \"%s\": %m",
 						tmppath)));
-	}
 
-	if (CloseTransientFile(tmpfd) != 0)
-		ereport(PANIC,
-				(errcode_for_file_access(),
-				 errmsg("could not close file \"%s\": %m",
-						tmppath)));
+	FileClose(file);
 
 	/* fsync, rename to permanent file, fsync file and directory */
 	durable_rename(tmppath, path, PANIC);
@@ -699,7 +679,7 @@ void
 StartupReplicationOrigin(void)
 {
 	const char *path = "pg_logical/replorigin_checkpoint";
-	int			fd;
+	File		file;
 	int			readBytes;
 	uint32		magic = REPLICATION_STATE_MAGIC;
 	int			last_state = 0;
@@ -721,22 +701,22 @@ StartupReplicationOrigin(void)
 
 	elog(DEBUG2, "starting up replication origin progress state");
 
-	fd = OpenTransientFile(path, O_RDONLY | PG_BINARY);
+	file = PathNameOpenTemporaryFile(path, O_RDONLY | PG_BINARY);
 
 	/*
 	 * might have had max_replication_slots == 0 last run, or we just brought
 	 * up a standby.
 	 */
-	if (fd < 0 && errno == ENOENT)
+	if (file < 0 && errno == ENOENT)
 		return;
-	else if (fd < 0)
+	else if (file < 0)
 		ereport(PANIC,
 				(errcode_for_file_access(),
 				 errmsg("could not open file \"%s\": %m",
 						path)));
 
 	/* verify magic, that is written even if nothing was active */
-	readBytes = read(fd, &magic, sizeof(magic));
+	readBytes = FileReadSeq(file, &magic, sizeof(magic), WAIT_EVENT_NONE);
 	if (readBytes != sizeof(magic))
 	{
 		if (readBytes < 0)
@@ -764,7 +744,7 @@ StartupReplicationOrigin(void)
 	{
 		ReplicationStateOnDisk disk_state;
 
-		readBytes = read(fd, &disk_state, sizeof(disk_state));
+		readBytes = FileReadSeq(file, &disk_state, sizeof(disk_state), WAIT_EVENT_NONE);
 
 		/* no further data */
 		if (readBytes == sizeof(crc))
@@ -816,11 +796,7 @@ StartupReplicationOrigin(void)
 				 errmsg("replication slot checkpoint has wrong checksum %u, expected %u",
 						crc, file_crc)));
 
-	if (CloseTransientFile(fd) != 0)
-		ereport(PANIC,
-				(errcode_for_file_access(),
-				 errmsg("could not close file \"%s\": %m",
-						path)));
+	FileClose(file);
 }
 
 void

--- a/src/backend/utils/activity/pgstat.c
+++ b/src/backend/utils/activity/pgstat.c
@@ -1260,14 +1260,9 @@ pgstat_assert_is_up(void)
 
 /* helpers for pgstat_write_statsfile() */
 static void
-write_chunk(FILE *fpout, void *ptr, size_t len)
+write_chunk(File file, void *ptr, size_t len)
 {
-	int			rc;
-
-	rc = fwrite(ptr, len, 1, fpout);
-
-	/* we'll check for errors with ferror once at the end */
-	(void) rc;
+	FileWriteSeq(file, ptr, len, WAIT_EVENT_NONE);
 }
 
 #define write_chunk_s(fpout, ptr) write_chunk(fpout, ptr, sizeof(*ptr))
@@ -1279,7 +1274,7 @@ write_chunk(FILE *fpout, void *ptr, size_t len)
 static void
 pgstat_write_statsfile(void)
 {
-	FILE	   *fpout;
+	File file;
 	int32		format_id;
 	const char *tmpfile = PGSTAT_STAT_PERMANENT_TMPFILE;
 	const char *statfile = PGSTAT_STAT_PERMANENT_FILENAME;
@@ -1296,8 +1291,8 @@ pgstat_write_statsfile(void)
 	/*
 	 * Open the statistics temp file to write out the current values.
 	 */
-	fpout = AllocateFile(tmpfile, PG_BINARY_W);
-	if (fpout == NULL)
+	file = PathNameOpenTemporaryFile(tmpfile, O_WRONLY | O_CREAT | O_TRUNC | PG_BINARY);
+	if (file < 0)
 	{
 		ereport(LOG,
 				(errcode_for_file_access(),
@@ -1310,7 +1305,7 @@ pgstat_write_statsfile(void)
 	 * Write the file header --- currently just a format ID.
 	 */
 	format_id = PGSTAT_FILE_FORMAT_ID;
-	write_chunk_s(fpout, &format_id);
+	write_chunk_s(file, &format_id);
 
 	/*
 	 * XXX: The following could now be generalized to just iterate over
@@ -1322,19 +1317,19 @@ pgstat_write_statsfile(void)
 	 * Write archiver stats struct
 	 */
 	pgstat_build_snapshot_fixed(PGSTAT_KIND_ARCHIVER);
-	write_chunk_s(fpout, &pgStatLocal.snapshot.archiver);
+	write_chunk_s(file, &pgStatLocal.snapshot.archiver);
 
 	/*
 	 * Write bgwriter stats struct
 	 */
 	pgstat_build_snapshot_fixed(PGSTAT_KIND_BGWRITER);
-	write_chunk_s(fpout, &pgStatLocal.snapshot.bgwriter);
+	write_chunk_s(file, &pgStatLocal.snapshot.bgwriter);
 
 	/*
 	 * Write checkpointer stats struct
 	 */
 	pgstat_build_snapshot_fixed(PGSTAT_KIND_CHECKPOINTER);
-	write_chunk_s(fpout, &pgStatLocal.snapshot.checkpointer);
+	write_chunk_s(file, &pgStatLocal.snapshot.checkpointer);
 
 	/*
 	 * Write IO stats struct
@@ -1346,13 +1341,13 @@ pgstat_write_statsfile(void)
 	 * Write SLRU stats struct
 	 */
 	pgstat_build_snapshot_fixed(PGSTAT_KIND_SLRU);
-	write_chunk_s(fpout, &pgStatLocal.snapshot.slru);
+	write_chunk_s(file, &pgStatLocal.snapshot.slru);
 
 	/*
 	 * Write WAL stats struct
 	 */
 	pgstat_build_snapshot_fixed(PGSTAT_KIND_WAL);
-	write_chunk_s(fpout, &pgStatLocal.snapshot.wal);
+	write_chunk_s(file, &pgStatLocal.snapshot.wal);
 
 	/*
 	 * Walk through the stats entries
@@ -1380,8 +1375,8 @@ pgstat_write_statsfile(void)
 		if (!kind_info->to_serialized_name)
 		{
 			/* normal stats entry, identified by PgStat_HashKey */
-			fputc('S', fpout);
-			write_chunk_s(fpout, &ps->key);
+			FilePutc('S', file);
+			write_chunk_s(file, &ps->key);
 		}
 		else
 		{
@@ -1390,13 +1385,13 @@ pgstat_write_statsfile(void)
 
 			kind_info->to_serialized_name(&ps->key, shstats, &name);
 
-			fputc('N', fpout);
-			write_chunk_s(fpout, &ps->key.kind);
-			write_chunk_s(fpout, &name);
+			FilePutc('N', file);
+			write_chunk_s(file, &ps->key.kind);
+			write_chunk_s(file, &name);
 		}
 
 		/* Write except the header part of the entry */
-		write_chunk(fpout,
+		write_chunk(file,
 					pgstat_get_entry_data(ps->key.kind, shstats),
 					pgstat_get_entry_len(ps->key.kind));
 	}
@@ -1407,25 +1402,18 @@ pgstat_write_statsfile(void)
 	 * pgstat.stat with it.  The ferror() check replaces testing for error
 	 * after each individual fputc or fwrite (in write_chunk()) above.
 	 */
-	fputc('E', fpout);
+	FilePutc('E', file);
+	FileClose(file);
 
-	if (ferror(fpout))
+	if (FileError(file))  /* TODO: This requires cumulative error */
 	{
 		ereport(LOG,
 				(errcode_for_file_access(),
-				 errmsg("could not write temporary statistics file \"%s\": %m",
-						tmpfile)));
-		FreeFile(fpout);
+					errmsg("could not write temporary statistics file \"%s\": %m",
+						   tmpfile)));
 		unlink(tmpfile);
 	}
-	else if (FreeFile(fpout) < 0)
-	{
-		ereport(LOG,
-				(errcode_for_file_access(),
-				 errmsg("could not close temporary statistics file \"%s\": %m",
-						tmpfile)));
-		unlink(tmpfile);
-	}
+
 	else if (rename(tmpfile, statfile) < 0)
 	{
 		ereport(LOG,
@@ -1438,12 +1426,12 @@ pgstat_write_statsfile(void)
 
 /* helpers for pgstat_read_statsfile() */
 static bool
-read_chunk(FILE *fpin, void *ptr, size_t len)
+read_chunk(File file, void *ptr, size_t len)
 {
-	return fread(ptr, 1, len, fpin) == len;
+	return FileReadSeq(file, ptr, len, WAIT_EVENT_NONE) == len;
 }
 
-#define read_chunk_s(fpin, ptr) read_chunk(fpin, ptr, sizeof(*ptr))
+#define read_chunk_s(file, ptr) read_chunk(file, ptr, sizeof(*ptr))
 
 /*
  * Reads in existing statistics file into the shared stats hash.
@@ -1454,7 +1442,7 @@ read_chunk(FILE *fpin, void *ptr, size_t len)
 static void
 pgstat_read_statsfile(void)
 {
-	FILE	   *fpin;
+	File	    file;
 	int32		format_id;
 	bool		found;
 	const char *statfile = PGSTAT_STAT_PERMANENT_FILENAME;
@@ -1474,7 +1462,8 @@ pgstat_read_statsfile(void)
 	 * has not yet written the stats file for the first time.  Any other
 	 * failure condition is suspicious.
 	 */
-	if ((fpin = AllocateFile(statfile, PG_BINARY_R)) == NULL)
+	file = PathNameOpenTemporaryFile(statfile, O_RDONLY | PG_BINARY);
+	if (file < 0)
 	{
 		if (errno != ENOENT)
 			ereport(LOG,
@@ -1488,7 +1477,7 @@ pgstat_read_statsfile(void)
 	/*
 	 * Verify it's of the expected format.
 	 */
-	if (!read_chunk_s(fpin, &format_id) ||
+	if (!read_chunk_s(file, &format_id) ||
 		format_id != PGSTAT_FILE_FORMAT_ID)
 		goto error;
 
@@ -1501,19 +1490,19 @@ pgstat_read_statsfile(void)
 	/*
 	 * Read archiver stats struct
 	 */
-	if (!read_chunk_s(fpin, &shmem->archiver.stats))
+	if (!read_chunk_s(file, &shmem->archiver.stats))
 		goto error;
 
 	/*
 	 * Read bgwriter stats struct
 	 */
-	if (!read_chunk_s(fpin, &shmem->bgwriter.stats))
+	if (!read_chunk_s(file, &shmem->bgwriter.stats))
 		goto error;
 
 	/*
 	 * Read checkpointer stats struct
 	 */
-	if (!read_chunk_s(fpin, &shmem->checkpointer.stats))
+	if (!read_chunk_s(file, &shmem->checkpointer.stats))
 		goto error;
 
 	/*
@@ -1525,13 +1514,13 @@ pgstat_read_statsfile(void)
 	/*
 	 * Read SLRU stats struct
 	 */
-	if (!read_chunk_s(fpin, &shmem->slru.stats))
+	if (!read_chunk_s(file, &shmem->slru.stats))
 		goto error;
 
 	/*
 	 * Read WAL stats struct
 	 */
-	if (!read_chunk_s(fpin, &shmem->wal.stats))
+	if (!read_chunk_s(file, &shmem->wal.stats))
 		goto error;
 
 	/*
@@ -1540,7 +1529,7 @@ pgstat_read_statsfile(void)
 	 */
 	for (;;)
 	{
-		int			t = fgetc(fpin);
+		int			t = FileGetc(file);
 
 		switch (t)
 		{
@@ -1556,7 +1545,7 @@ pgstat_read_statsfile(void)
 					if (t == 'S')
 					{
 						/* normal stats entry, identified by PgStat_HashKey */
-						if (!read_chunk_s(fpin, &key))
+						if (!read_chunk_s(file, &key))
 							goto error;
 
 						if (!pgstat_is_kind_valid(key.kind))
@@ -1569,9 +1558,9 @@ pgstat_read_statsfile(void)
 						PgStat_Kind kind;
 						NameData	name;
 
-						if (!read_chunk_s(fpin, &kind))
+						if (!read_chunk_s(file, &kind))
 							goto error;
-						if (!read_chunk_s(fpin, &name))
+						if (!read_chunk_s(file, &name))
 							goto error;
 						if (!pgstat_is_kind_valid(kind))
 							goto error;
@@ -1584,7 +1573,7 @@ pgstat_read_statsfile(void)
 						if (!kind_info->from_serialized_name(&name, &key))
 						{
 							/* skip over data for entry we don't care about */
-							if (fseek(fpin, pgstat_get_entry_len(kind), SEEK_CUR) != 0)
+							if (FileSeek(file, FileTell(file) + pgstat_get_entry_len(kind)) < 0)
 								goto error;
 
 							continue;
@@ -1612,7 +1601,7 @@ pgstat_read_statsfile(void)
 					header = pgstat_init_entry(key.kind, p);
 					dshash_release_lock(pgStatLocal.shared_hash, p);
 
-					if (!read_chunk(fpin,
+					if (!read_chunk(file,
 									pgstat_get_entry_data(key.kind, header),
 									pgstat_get_entry_len(key.kind)))
 						goto error;
@@ -1621,7 +1610,7 @@ pgstat_read_statsfile(void)
 				}
 			case 'E':
 				/* check that 'E' actually signals end of file */
-				if (fgetc(fpin) != EOF)
+				if (FileGetc(file) != EOF)
 					goto error;
 
 				goto done;
@@ -1632,7 +1621,7 @@ pgstat_read_statsfile(void)
 	}
 
 done:
-	FreeFile(fpin);
+	FileClose(file);
 
 	elog(DEBUG2, "removing permanent stats file \"%s\"", statfile);
 	unlink(statfile);

--- a/src/backend/utils/activity/wait_event.c
+++ b/src/backend/utils/activity/wait_event.c
@@ -756,6 +756,9 @@ pgstat_get_wait_io(WaitEventIO w)
 		case WAIT_EVENT_WAL_WRITE:
 			event_name = "WALWrite";
 			break;
+		case WAIT_EVENT_NONE:
+			event_name = "None";
+			break;
 
 			/* no default case, so that compiler will warn */
 	}

--- a/src/backend/utils/cache/relmapper.c
+++ b/src/backend/utils/cache/relmapper.c
@@ -783,7 +783,7 @@ read_relmap_file(RelMapFile *map, char *dbpath, bool lock_held, int elevel)
 {
 	char		mapfilename[MAXPGPATH];
 	pg_crc32c	crc;
-	int			fd;
+	File			file;
 	int			r;
 
 	Assert(elevel >= ERROR);
@@ -806,21 +806,26 @@ read_relmap_file(RelMapFile *map, char *dbpath, bool lock_held, int elevel)
 	 * and for the same reason, we close it before releasing the lock. That
 	 * way, by the time write_relmap_file() acquires an exclusive lock, no
 	 * one else will have it open.
+	 * Since this code is invoked during startup before a resource owner is active,
+	 * we close the file ourselves if an error occurs.
 	 */
 	snprintf(mapfilename, sizeof(mapfilename), "%s/%s", dbpath,
 			 RELMAPPER_FILENAME);
-	fd = OpenTransientFile(mapfilename, O_RDONLY | PG_BINARY);
-	if (fd < 0)
+	file = PathNameOpenFile(mapfilename, O_RDONLY | PG_BINARY);
+	if (file < 0)
 		ereport(elevel,
 				(errcode_for_file_access(),
 				 errmsg("could not open file \"%s\": %m",
 						mapfilename)));
 
 	/* Now read the data. */
-	pgstat_report_wait_start(WAIT_EVENT_RELATION_MAP_READ);
-	r = read(fd, map, sizeof(RelMapFile));
+	r = FileReadSeq(file, map, sizeof(RelMapFile), WAIT_EVENT_RELATION_MAP_READ);
 	if (r != sizeof(RelMapFile))
 	{
+		int save_errno = errno;
+		FileClose(file);
+		errno = save_errno;
+
 		if (r < 0)
 			ereport(elevel,
 					(errcode_for_file_access(),
@@ -831,13 +836,8 @@ read_relmap_file(RelMapFile *map, char *dbpath, bool lock_held, int elevel)
 					 errmsg("could not read file \"%s\": read %d of %zu",
 							mapfilename, r, sizeof(RelMapFile))));
 	}
-	pgstat_report_wait_end();
 
-	if (CloseTransientFile(fd) != 0)
-		ereport(elevel,
-				(errcode_for_file_access(),
-				 errmsg("could not close file \"%s\": %m",
-						mapfilename)));
+	FileClose(file);
 
 	if (!lock_held)
 		LWLockRelease(RelationMappingLock);
@@ -887,7 +887,7 @@ static void
 write_relmap_file(RelMapFile *newmap, bool write_wal, bool send_sinval,
 				  bool preserve_files, Oid dbid, Oid tsid, const char *dbpath)
 {
-	int			fd;
+	File		file;
 	char		mapfilename[MAXPGPATH];
 	char		maptempfilename[MAXPGPATH];
 
@@ -912,38 +912,36 @@ write_relmap_file(RelMapFile *newmap, bool write_wal, bool send_sinval,
 			 dbpath, RELMAPPER_TEMP_FILENAME);
 
 	/*
-	 * Open a temporary file. If a file already exists with this name, it must
+	 * Open a virtual file. If a file already exists with this name, it must
 	 * be left over from a previous crash, so we can overwrite it. Concurrent
 	 * calls to this function are not allowed.
 	 */
-	fd = OpenTransientFile(maptempfilename,
+	file = PathNameOpenFile(maptempfilename,
 						   O_WRONLY | O_CREAT | O_TRUNC | PG_BINARY);
-	if (fd < 0)
+	if (file < 0)
 		ereport(ERROR,
 				(errcode_for_file_access(),
 				 errmsg("could not open file \"%s\": %m",
 						maptempfilename)));
 
-	/* Write new data to the file. */
-	pgstat_report_wait_start(WAIT_EVENT_RELATION_MAP_WRITE);
-	if (write(fd, newmap, sizeof(RelMapFile)) != sizeof(RelMapFile))
+	/*
+	 * Write new data to the file.
+	 * We may be invoked during bootstrap, so we do our own cleanup
+	 * rather than depending on the resource owner to close the file.
+	 */
+	if (FileWriteSeq(file, newmap, sizeof(RelMapFile), WAIT_EVENT_RELATION_MAP_WRITE) != sizeof(RelMapFile))
 	{
-		/* if write didn't set errno, assume problem is no disk space */
-		if (errno == 0)
-			errno = ENOSPC;
+		int save_errno = errno;
+		FileClose(file);
+		errno = save_errno;
 		ereport(ERROR,
 				(errcode_for_file_access(),
-				 errmsg("could not write file \"%s\": %m",
-						maptempfilename)));
+					errmsg("could not write file \"%s\": %m",
+						   maptempfilename)));
 	}
-	pgstat_report_wait_end();
 
 	/* And close the file. */
-	if (CloseTransientFile(fd) != 0)
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not close file \"%s\": %m",
-						maptempfilename)));
+	FileClose(file);
 
 	if (write_wal)
 	{

--- a/src/include/storage/fd.h
+++ b/src/include/storage/fd.h
@@ -44,7 +44,7 @@
 #define FD_H
 
 #include <dirent.h>
-#include <fcntl.h>
+#include "c.h"
 
 typedef enum RecoveryInitSyncMethod
 {
@@ -111,8 +111,8 @@ extern File PathNameOpenFilePerm(const char *fileName, int fileFlags, mode_t fil
 extern File OpenTemporaryFile(bool interXact);
 extern void FileClose(File file);
 extern int	FilePrefetch(File file, off_t offset, off_t amount, uint32 wait_event_info);
-extern int	FileRead(File file, void *buffer, size_t amount, off_t offset, uint32 wait_event_info);
-extern int	FileWrite(File file, const void *buffer, size_t amount, off_t offset, uint32 wait_event_info);
+extern ssize_t	FileRead(File file, void *buffer, size_t amount, off_t offset, uint32 wait_event_info);
+extern ssie_t	FileWrite(File file, const void *buffer, size_t amount, off_t offset, uint32 wait_event_info);
 extern int	FileSync(File file, uint32 wait_event_info);
 extern int	FileZero(File file, off_t offset, off_t amount, uint32 wait_event_info);
 extern int	FileFallocate(File file, off_t offset, off_t amount, uint32 wait_event_info);
@@ -124,6 +124,22 @@ extern char *FilePathName(File file);
 extern int	FileGetRawDesc(File file);
 extern int	FileGetRawFlags(File file);
 extern mode_t FileGetRawMode(File file);
+extern int PathNameFileSync(const char *path, uint32 wait_event_info);
+
+/* Operations on virtual files -- Sequential I/O */
+extern ssize_t FileReadSeq(File file, void *buffer, size_t amount, uint32 wait_event_info);
+extern ssize_t FileWriteSeq(File file, const void *buffer, size_t amount, uint32 wait_event_info);
+extern off_t FileTell(File file);
+extern off_t FileSeek(File file, off_t offset);
+
+/* Operations on virtual files --- equivalent to fread/fwrite */
+extern int FileGetc(File file);
+extern int FilePutc(int c, File file);
+extern void FileClearError(File file);
+extern int FileError(File file);
+extern int FileEof(File file);
+extern int FilePrintf(File file, const char *format, ...);
+extern int FileScanf(File file, const char *format, ...);
 
 /* Operations used for sharing named temporary files */
 extern File PathNameCreateTemporaryFile(const char *path, bool error_on_failure);

--- a/src/include/utils/wait_event.h
+++ b/src/include/utils/wait_event.h
@@ -234,7 +234,8 @@ typedef enum
 	WAIT_EVENT_WAL_READ,
 	WAIT_EVENT_WAL_SYNC,
 	WAIT_EVENT_WAL_SYNC_METHOD_ASSIGN,
-	WAIT_EVENT_WAL_WRITE
+	WAIT_EVENT_WAL_WRITE,
+	WAIT_EVENT_NONE,	/* Placeholder when not interested in timing */
 } WaitEventIO;
 
 


### PR DESCRIPTION
Unified File Access
Overview
Part of task for adding encryption to the “other” Postgres files.
-	Buffered data files and Write Ahead Log are done elsewhere.
-	Support encryption for all other files which may contain customer data.
-	Replaces most uses of Transient and Basic files in favor of Virtual FD (“File”) files.

Adding encryption to the “other” files is done in multiple steps. I
1)	Create a set of unified file access routines, and 
2)	update existing code to use these new routines.
3)	Create an “I/O Stack” framework for encryption and compression, and
4)	Integrate I/O stacks into the file access routines. Finally,
5)	update existing code to use the appropriate I/O stack.

This branch of code addresses steps 1) and 2).  The other steps will be presented later.

1.	Create Unified File Access Routines.
Postgres has a number of interfaces for accessing files, ranging from BufFiles and TemporaryFiles  to Transient and Basic files. With the exception of “Basic” and “Transient” files, most Postgres files are channeled through the “File” interface.

This “File” interface includes the following routines:
     PathNameOpenFile() – opens a Posix type file, returning a “File” type descriptor.
     FileRead() – pread() style interface doing both a random seek and a read.
     FileWrite() – pwrite() style interface to do random seek and a write
     FileClose() – close the file and release resources.

While these existing routines are useful for many situations, they are awkward for sequential I/O and for error handling. Our approach is to define additional routines in the spirit of fread(), fwrite() and ferror(). These routines, sitting on top of FileRead/FileWrite, make it convenient to replace existing uses of Basic and Transient files.

The new routines include:
    FileWriteSeq() – write to the file sequentially.
    FileReadSeq() – read from the file sequentially.
    FileSeek() – seek to a random position in the file
    FileError() – true if an error was encountered.
    FileEof() – true if the last read encountered end of file.
    FileErrorInfo() – returns the error code and an error message of the last error.
    FileClearError() – reset the error and EOF status
    FileOpen() – an optional alias for PathNameOpenFile(), but supporting O_APPEND.

The existing “File” interface also includes procedures like FileSync and FileSize. Those procedures are included “as is”.  Additionally, some of the existing routines which currently return “int” will be updated to return ssize_t or off_t.

The main code changes are in files fd.c and fd.h in the set of links below. (Should break them out as a separate branch)

2.	Update existing code to use the new routines
Look for calls to OpenTransitoryFile and OpenBasicFile. For those files containing customer data, convert them to the “File” interface.

Links:
[branch UnifiedFileAccess (github)](https://github.com/precision-software/postgres/tree/UnifiedFileAccess)
[diffs UnifiedFileAccess](https://github.com/precision-software/postgres/commit/8bc9a4e64f11321f029a94b70e237b3adcf0f6ee#diff-0625c721b1a78a590860ed86c0de985c5bd9d0911934803c3ab5b2ed22e50975)